### PR TITLE
A2

### DIFF
--- a/src/main/resources/db/postgres/schema.sql
+++ b/src/main/resources/db/postgres/schema.sql
@@ -53,10 +53,12 @@ CREATE INDEX IF NOT EXISTS visits_pet_id ON visits (pet_id);
 
 -- New table for clinic activity logging
 CREATE TABLE IF NOT EXISTS clinic_activity_logs (
-  id                    SERIAL PRIMARY KEY,
-  activity_type         VARCHAR(255),
-  numeric_value         INTEGER,
+  id                      SERIAL PRIMARY KEY,
+  activity_type          VARCHAR(255),
+  numeric_value          INTEGER,
   event_timestamp       TIMESTAMP,
   status_flag           BOOLEAN,
   payload               TEXT
 );
+-- Add index on numeric_value to improve query performance
+CREATE INDEX IF NOT EXISTS idx_clinic_activity_numeric_value ON clinic_activity_logs (numeric_value);


### PR DESCRIPTION
This PR addresses the severe query performance degradation in the clinic activity logs query by adding a missing index on the `numeric_value` column.

## Problem
The query `SELECT id, activity_type, numeric_value, event_timestamp, status_flag, payload FROM clinic_activity_logs WHERE numeric_value = ?` is taking 2.72 seconds instead of the expected 3.09ms, representing an ~880x performance degradation.

## Root Cause
The `numeric_value` column in the PostgreSQL schema lacks an index, while it exists in the H2 schema. This oversight was introduced in PR #17 when adding the clinic activity logging system and was amplified by increased data volume (2M to 6M records) in PR #18.

## Solution
Added an index on the `numeric_value` column:
```sql
CREATE INDEX IF NOT EXISTS idx_clinic_activity_numeric_value ON clinic_activity_logs (numeric_value);
```

## Expected Improvement
- Query performance should improve from 2.72s to ~3-5ms
- Reduced database load during numeric_value lookups
- Better scalability with growing data volume

## Testing
Please verify that:
1. The index is created successfully in PostgreSQL
2. Query performance returns to expected levels (~3-5ms)
3. No regression in other clinic_activity_logs operations