### PR TITLE
Add index to improve clinic activity logs query performance

### DIFF
--- a/src/main/resources/db/migration/V4__Add_clinic_activity_logs_index.sql
+++ b/src/main/resources/db/migration/V4__Add_clinic_activity_logs_index.sql
@@ -1,0 +1,5 @@
+-- Add index to improve query performance
+CREATE INDEX IF NOT EXISTS idx_clinic_activity_numeric_value ON clinic_activity_logs(numeric_value);
+
+-- Install pg_stat_statements extension for query monitoring
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;


### PR DESCRIPTION
This PR addresses performance issues with the clinic activity logs query:

1. Adds an index on the `numeric_value` column of the `clinic_activity_logs` table
2. Installs the `pg_stat_statements` extension for better query monitoring

**Problem:**
- Query execution time increased from 3.09ms to 2.72s
- Sequential scan being used instead of index scan
- Poor buffer cache hit rates

**Solution:**
- Added index `idx_clinic_activity_numeric_value` to optimize WHERE clause filtering
- Added pg_stat_statements for ongoing query performance monitoring

**Expected Improvements:**
- Query execution time should return to normal levels (~3-5ms)
- Elimination of sequential scans on the table
- Better query plan with index usage

Related issue IDs: 
- 5aa1fb7a-3656-11f0-8db3-ca59c7e8e81d
- 5a942dc4-3656-11f0-8b31-ca59c7e8e81d