### PR TITLE
Fix: Remove redundant findAll call in PetClinicIntegrationTests

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationTests.java
@@ -46,7 +46,6 @@ public class PetClinicIntegrationTests {
 	@Test
 	void testFindAll() throws Exception {
 		vets.findAll();
-		vets.findAll(); // served from cache
 	}
 
 	@Test


### PR DESCRIPTION
This PR removes a redundant call to `vets.findAll()` in the `testFindAll()` method of the `PetClinicIntegrationTests.java` file. The second call was unnecessary as the data would likely be served from cache or be identical to the first call.