### PR TITLE
Archive 6

### DIFF
--- a/src/main/resources/db/postgres/schema.sql
+++ b/src/main/resources/db/postgres/schema.sql
@@ -60,3 +60,4 @@ CREATE TABLE IF NOT EXISTS clinic_activity_logs (
   status_flag           BOOLEAN,
   payload               TEXT
 );
+CREATE INDEX IF NOT EXISTS idx_clinic_activity_logs_numeric_value ON clinic_activity_logs (numeric_value);


### PR DESCRIPTION
This PR addresses a performance issue with the clinic_activity_logs table queries where the execution time increased from 3.09ms to 2.72 seconds.

Problem:
- Query performing full sequential scan on clinic_activity_logs table
- Low table cache hit rate (6.5%)
- Missing index on numeric_value column causing poor performance

Changes:
- Added B-tree index on numeric_value column to improve query performance
- Index will help queries with WHERE numeric_value = ? predicates
- Expected to reduce query time back to millisecond range

Testing:
- Verified query plan shows index usage
- Performance improvement from 2.72s to expected ms range
- No impact on write performance as numeric_value is not frequently updated

Related issue: #performance-5aa1fb7a