### PR TITLE
Fix MonitorService IllegalStateException-created-by-agentic

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/errors/MonitorService.java
+++ b/src/main/java/org/springframework/samples/petclinic/errors/MonitorService.java
@@ -3,75 +3,78 @@ package org.springframework.samples.petclinic.errors;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.stereotype.Component;
 
-import java.util.InvalidPropertiesFormatException;
-
 @Component
 public class MonitorService implements SmartLifecycle {
 
-	private boolean running = false;
-	private Thread backgroundThread;
-	@Autowired
-	private OpenTelemetry openTelemetry;
+    private static final Logger logger = LoggerFactory.getLogger(MonitorService.class);
+    private volatile boolean running = false;
+    private Thread backgroundThread;
+    @Autowired
+    private OpenTelemetry openTelemetry;
 
-	@Override
-	public void start() {
-		var otelTracer = openTelemetry.getTracer("MonitorService");
+    @Override
+    public void start() {
+        var otelTracer = openTelemetry.getTracer("MonitorService");
 
-		running = true;
-		backgroundThread = new Thread(() -> {
-			while (running) {
+        running = true;
+        backgroundThread = new Thread(() -> {
+            while (running) {
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException e) {
+                    logger.warn("Monitor thread interrupted", e);
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+                Span span = otelTracer.spanBuilder("monitor").startSpan();
 
-				try {
-					Thread.sleep(5000);
-				} catch (InterruptedException e) {
-					throw new RuntimeException(e);
-				}
-				Span span = otelTracer.spanBuilder("monitor").startSpan();
+                try {
+                    logger.info("Background service is running...");
+                    monitor();
+                } catch (Exception e) {
+                    logger.error("Error in monitor service", e);
+                    span.recordException(e);
+                    span.setStatus(StatusCode.ERROR);
+                } finally {
+                    span.end();
+                }
+            }
+        });
 
-				try {
+        backgroundThread.start();
+        logger.info("Background service started.");
+    }
 
-					System.out.println("Background service is running...");
-					monitor();
-				} catch (Exception e) {
-					span.recordException(e);
-					span.setStatus(StatusCode.ERROR);
-				} finally {
-					span.end();
-				}
-			}
-		});
+    private void monitor() {
+        if (!running) {
+            logger.warn("Monitor called while service is not running");
+            return;
+        }
+        logger.debug("Performing monitoring check");
+    }
 
-		// Start the background thread
-		backgroundThread.start();
-		System.out.println("Background service started.");
-	}
+    @Override
+    public void stop() {
+        running = false;
+        if (backgroundThread != null) {
+            try {
+                backgroundThread.join();
+            } catch (InterruptedException e) {
+                logger.warn("Interrupted while stopping background thread", e);
+                Thread.currentThread().interrupt();
+            }
+        }
+        logger.info("Background service stopped.");
+    }
 
-	private void monitor() throws InvalidPropertiesFormatException {
-		Utils.throwException(IllegalStateException.class,"monitor failure");
-	}
-
-
-
-	@Override
-	public void stop() {
-		// Stop the background task
-		running = false;
-		if (backgroundThread != null) {
-			try {
-				backgroundThread.join(); // Wait for the thread to finish
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-			}
-		}
-		System.out.println("Background service stopped.");
-	}
-
-	@Override
-	public boolean isRunning() {
-		return false;
-	}
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
 }


### PR DESCRIPTION
This PR fixes the IllegalStateException in MonitorService by:

1. Fixing the isRunning() method to return actual state
2. Adding proper state validation in monitor() method
3. Adding logging for better diagnostics
4. Removing intentional exception throwing

Related to incident: b2f3824a-3655-11f0-bc70-ca59c7e8e81d