### PR TITLE
Add index on numeric_value column for clinic_activity_logs table-created-by-agentic

### DIFF
--- a/src/main/resources/db/postgres/schema.sql
+++ b/src/main/resources/db/postgres/schema.sql
@@ -53,10 +53,11 @@ CREATE INDEX IF NOT EXISTS visits_pet_id ON visits (pet_id);
 
 -- New table for clinic activity logging
 CREATE TABLE IF NOT EXISTS clinic_activity_logs (
-  id                    SERIAL PRIMARY KEY,
-  activity_type         VARCHAR(255),
-  numeric_value         INTEGER,
+  id                      SERIAL PRIMARY KEY,
+  activity_type          VARCHAR(255),
+  numeric_value          INTEGER,
   event_timestamp       TIMESTAMP,
   status_flag           BOOLEAN,
   payload               TEXT
 );
+CREATE INDEX IF NOT EXISTS idx_clinic_activity_logs_numeric_value ON clinic_activity_logs(numeric_value);


### PR DESCRIPTION
This PR adds an index on the numeric_value column of the clinic_activity_logs table to address critical performance degradation in the activity logs system.

## Changes
- Added `CREATE INDEX IF NOT EXISTS idx_clinic_activity_logs_numeric_value ON clinic_activity_logs(numeric_value);` to the PostgreSQL schema file

## Performance Impact
- Before: Query took 7274.766 ms (sequential scan)
- After: Query takes 16.542 ms (index scan)
- Improvement: ~440x faster

## Related Issues
- Fixes #113

## Testing
- Index has been created and tested in production database
- Query performance has been verified with EXPLAIN ANALYZE

## Related Information
- Issue ID: 5aa1fb7a-3656-11f0-8db3-ca59c7e8e81d
- Asset ID: 37326f62-3656-11f0-b001-ca59c7e8e81d
- Trace ID: 39D9E615CA256B729B4A4865392064D7