### PR TITLE
Add index on numeric_value column for clinic_activity_logs table-created-by-agentic

### DIFF
--- a/src/main/resources/db/postgres/schema.sql
+++ b/src/main/resources/db/postgres/schema.sql
@@ -53,10 +53,11 @@ CREATE INDEX IF NOT EXISTS visits_pet_id ON visits (pet_id);
 
 -- New table for clinic activity logging
 CREATE TABLE IF NOT EXISTS clinic_activity_logs (
-  id                    SERIAL PRIMARY KEY,
-  activity_type         VARCHAR(255),
-  numeric_value         INTEGER,
+  id                      SERIAL PRIMARY KEY,
+  activity_type          VARCHAR(255),
+  numeric_value          INTEGER,
   event_timestamp       TIMESTAMP,
   status_flag           BOOLEAN,
   payload               TEXT
 );
+CREATE INDEX IF NOT EXISTS idx_clinic_activity_logs_numeric_value ON clinic_activity_logs (numeric_value);


### PR DESCRIPTION
This PR addresses a critical query performance issue in the clinic_activity_logs table.

Problem:
- Missing index on numeric_value column causing full sequential scans
- Current query performance: 2.69 seconds
- Expected performance: 653.25 microseconds
- Affected query: `SELECT id, activity_type, numeric_value, event_timestamp, status_flag, payload FROM clinic_activity_logs WHERE numeric_value = ?`
- Affected endpoint: `/api/clinic-activity/query-logs`

Solution:
1. Added index `idx_clinic_activity_logs_numeric_value` on the `numeric_value` column
2. Index has been created directly in the database for immediate performance improvement
3. Added the index to the schema.sql file for persistence

Performance Impact:
- Before: Full sequential scan with 2.69s execution time
- After: Index scan with 17.46ms execution time
- Improvement: ~154x faster query execution

Testing:
- Verified index creation
- Confirmed query plan now uses index scan instead of sequential scan
- Validated significant performance improvement