### PR TITLE
Add index on clinic_activity_logs.numeric_value for improved query performance-created-by-agentic

### DIFF
--- a/src/main/resources/db/postgres/schema.sql
+++ b/src/main/resources/db/postgres/schema.sql
@@ -56,7 +56,9 @@ CREATE TABLE IF NOT EXISTS clinic_activity_logs (
   id                    SERIAL PRIMARY KEY,
   activity_type         VARCHAR(255),
   numeric_value         INTEGER,
-  event_timestamp       TIMESTAMP,
-  status_flag           BOOLEAN,
-  payload               TEXT
+  event_timestamp      TIMESTAMP,
+  status_flag          BOOLEAN,
+  payload              TEXT
 );
+-- Add index for numeric_value to improve query performance
+CREATE INDEX IF NOT EXISTS idx_clinic_activity_logs_numeric_value ON clinic_activity_logs(numeric_value);


### PR DESCRIPTION
This PR addresses a critical performance issue in the clinic_activity_logs query that was causing significant performance degradation in the /api/clinic-activity/query-logs endpoint.

Problem:
- Query execution time increased from 653.25μs to 2.67s
- Sequential scan on the entire clinic_activity_logs table
- Low table cache hit rate (21.7%)

Solution:
- Added an index on the numeric_value column of the clinic_activity_logs table
- Index will improve query performance by avoiding full table scans
- Expected to significantly reduce query execution time

Related Issue: #5aa1fb7a-3656-11f0-8db3-ca59c7e8e81d