### PR TITLE
Fix N+1 Query Performance Issues-created-by-agentic

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/config/CacheConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/config/CacheConfig.java
@@ -1,0 +1,11 @@
+package org.springframework.samples.petclinic.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+    // Cache configuration is enabled via annotations
+    // Additional cache configuration can be added here if needed
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
@@ -15,9 +15,7 @@
  */
 package org.springframework.samples.petclinic.owner;
 
-import java.util.List;
-
-import org.springframework.data.domain.Page;
+import java.util.List;import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -34,8 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Juergen Hoeller
  * @author Sam Brannen
  * @author Michael Isvy
- */
-public interface OwnerRepository extends Repository<Owner, Integer> {
+ */public interface OwnerRepository extends Repository<Owner, Integer> {
 
 	/**
 	 * Retrieve all {@link PetType}s from the data store.
@@ -43,6 +40,7 @@ public interface OwnerRepository extends Repository<Owner, Integer> {
 	 */
 	@Query("SELECT ptype FROM PetType ptype ORDER BY ptype.name")
 	@Transactional(readOnly = true)
+	@Cacheable("petTypes")
 	List<PetType> findPetTypes();
 
 	/**
@@ -53,16 +51,14 @@ public interface OwnerRepository extends Repository<Owner, Integer> {
 	 * found)
 	 */
 
-	@Query("SELECT DISTINCT owner FROM Owner owner left join  owner.pets WHERE owner.lastName LIKE :lastName% ")
+	@Query("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets pets left join fetch pets.visits WHERE owner.lastName LIKE :lastName% ")
 	@Transactional(readOnly = true)
-	Page<Owner> findByLastName(@Param("lastName") String lastName, Pageable pageable);
-
-	/**
+	Page<Owner> findByLastName(@Param("lastName") String lastName, Pageable pageable);/**
 	 * Retrieve an {@link Owner} from the data store by id.
 	 * @param id the id to search for
 	 * @return the {@link Owner} if found
 	 */
-	@Query("SELECT owner FROM Owner owner left join fetch owner.pets WHERE owner.id =:id")
+	@Query("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets pets left join fetch pets.visits WHERE owner.id =:id")
 	@Transactional(readOnly = true)
 	Owner findById(@Param("id") Integer id);
 


### PR DESCRIPTION
This PR addresses multiple N+1 query performance issues in the Pet Management functionality:

1. Added caching for pet types using Spring's @Cacheable annotation
2. Optimized owner queries to fetch pets and visits data in single queries
3. Added cache configuration

Changes:
- Added CacheConfig.java to enable caching
- Modified OwnerRepository.java to optimize queries and add caching
- Updated JPQL queries to use join fetch for eager loading

Related issues:
- b2f26188-3b8e-11f0-9ce9-42975a299f33 (Primary)
- b2786e3c-3b8e-11f0-9159-42975a299f33
- b2a6aa54-3b8e-11f0-bec8-42975a299f33

Performance Impact:
- Eliminates repeated queries for pet types
- Reduces N+1 queries for pets and visits data
- Improves cache hit rate for frequently accessed data