### PR TITLE
docs: Document intentional IllegalStateException in MonitorService-created-by-agentic

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/errors/MonitorService.java
+++ b/src/main/java/org/springframework/samples/petclinic/errors/MonitorService.java
@@ -9,7 +9,11 @@ import org.springframework.stereotype.Component;
 
 import java.util.InvalidPropertiesFormatException;
 
-@Component
+@Component/**
+ * A monitoring service that simulates error conditions for demonstration purposes.
+ * This service intentionally throws IllegalStateException every 5 seconds
+ * as part of the application's error simulation functionality.
+ */
 public class MonitorService implements SmartLifecycle {
 
 	private boolean running = false;
@@ -48,30 +52,34 @@ public class MonitorService implements SmartLifecycle {
 		// Start the background thread
 		backgroundThread.start();
 		System.out.println("Background service started.");
-	}
+	}/**
+ * Monitors the system state. This method intentionally throws an IllegalStateException
+ * every 5 seconds as part of the application's error simulation functionality.
+ * The exception is used for demonstration purposes.
+ *
+ * @throws InvalidPropertiesFormatException if there's an invalid property format
+ */
+private void monitor() throws InvalidPropertiesFormatException {
+	Utils.throwException(IllegalStateException.class,"monitor failure");
+}
 
-	private void monitor() throws InvalidPropertiesFormatException {
-		Utils.throwException(IllegalStateException.class,"monitor failure");
-	}
 
-
-
-	@Override
-	public void stop() {
-		// Stop the background task
-		running = false;
-		if (backgroundThread != null) {
-			try {
-				backgroundThread.join(); // Wait for the thread to finish
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-			}
+@Override
+public void stop() {
+	// Stop the background task
+	running = false;
+	if (backgroundThread != null) {
+		try {
+			backgroundThread.join(); // Wait for the thread to finish
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
 		}
-		System.out.println("Background service stopped.");
 	}
+	System.out.println("Background service stopped.");
+}
 
-	@Override
-	public boolean isRunning() {
-		return false;
-	}
+@Override
+public boolean isRunning() {
+	return false;
+}
 }


### PR DESCRIPTION
This PR adds documentation to clarify that the IllegalStateException thrown in MonitorService is intentional behavior used for demonstration purposes.

Changes:
- Added class-level documentation explaining the service's error simulation purpose
- Added method-level documentation for the monitor() method explaining the intentional exception
- Clarified that the exception is thrown every 5 seconds as expected behavior

This documentation will help prevent future false alarms and make it clear that this is part of the application's error simulation functionality.