### PR TITLE
Document MonitorService Exception Simulation-created-by-agentic

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/errors/MonitorService.java
+++ b/src/main/java/org/springframework/samples/petclinic/errors/MonitorService.java
@@ -9,7 +9,17 @@ import org.springframework.stereotype.Component;
 
 import java.util.InvalidPropertiesFormatException;
 
+/**
+ * A service component that demonstrates error handling and monitoring capabilities.
+ * This class implements SmartLifecycle to showcase lifecycle management and
+ * intentionally throws exceptions for demonstration purposes.
+ */
 @Component
+/**
+ * A service that implements SmartLifecycle to provide continuous monitoring functionality.
+ * This service runs in the background and performs periodic monitoring operations
+ * while integrating with OpenTelemetry for observability.
+ */
 public class MonitorService implements SmartLifecycle {
 
 	private boolean running = false;
@@ -48,30 +58,32 @@ public class MonitorService implements SmartLifecycle {
 		// Start the background thread
 		backgroundThread.start();
 		System.out.println("Background service started.");
-	}
+	}/**
+ * Monitors the service state. This method intentionally throws an IllegalStateException
+ * for demonstration purposes to simulate a monitoring failure.
+ * @throws InvalidPropertiesFormatException if properties are invalid
+ */
+private void monitor() throws InvalidPropertiesFormatException {
+	Utils.throwException(IllegalStateException.class,"monitor failure");
+}
 
-	private void monitor() throws InvalidPropertiesFormatException {
-		Utils.throwException(IllegalStateException.class,"monitor failure");
-	}
 
-
-
-	@Override
-	public void stop() {
-		// Stop the background task
-		running = false;
-		if (backgroundThread != null) {
-			try {
-				backgroundThread.join(); // Wait for the thread to finish
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-			}
+@Override
+public void stop() {
+	// Stop the background task
+	running = false;
+	if (backgroundThread != null) {
+		try {
+			backgroundThread.join(); // Wait for the thread to finish
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
 		}
-		System.out.println("Background service stopped.");
 	}
+	System.out.println("Background service stopped.");
+}
 
-	@Override
-	public boolean isRunning() {
-		return false;
-	}
+@Override
+public boolean isRunning() {
+	return false;
+}
 }

--- a/src/main/java/org/springframework/samples/petclinic/errors/Utils.java
+++ b/src/main/java/org/springframework/samples/petclinic/errors/Utils.java
@@ -1,8 +1,6 @@
 package org.springframework.samples.petclinic.errors;
 
-import org.apache.coyote.BadRequestException;
-
-public class Utils {
+import org.apache.coyote.BadRequestException;public class Utils {
 	public static void ThrowIllegalStateException() throws IllegalStateException {
 		throw new IllegalStateException("Some unexpected state error");
 	}
@@ -13,16 +11,24 @@ public class Utils {
 
 	public static void ThrowUnsupportedOperationException() throws UnsupportedOperationException {
 		throw new UnsupportedOperationException("operation is not supported");
-	}
-
-	public static <T extends Exception> void throwException(Class<T> exceptionClass, String message) throws T {
-		try {
-			// Use reflection to create a new instance of the exception with the message
-			T exceptionInstance = exceptionClass.getConstructor(String.class).newInstance(message);
-			throw exceptionInstance;
-		} catch (ReflectiveOperationException e) {
-			// Handle case where the exception type doesn't have the expected constructor
-			throw new IllegalArgumentException("Invalid exception type provided", e);
-		}
-	}
+	}    /**
+     * Utility method for simulating exceptions and testing error handling.
+     * This method is for demonstration purposes only and allows dynamic creation
+     * and throwing of specified exception types.
+     *
+     * @param <T> The type of exception to throw
+     * @param exceptionClass The class of the exception to be thrown
+     * @param message The error message for the exception
+     * @throws T The specified exception type
+     */
+    public static <T extends Exception> void throwException(Class<T> exceptionClass, String message) throws T {
+        try {
+            // Use reflection to create a new instance of the exception with the message
+            T exceptionInstance = exceptionClass.getConstructor(String.class).newInstance(message);
+            throw exceptionInstance;
+        } catch (ReflectiveOperationException e) {
+            // Handle case where the exception type doesn't have the expected constructor
+            throw new IllegalArgumentException("Invalid exception type provided", e);
+        }
+    }
 }


### PR DESCRIPTION
This PR adds documentation to clarify that the IllegalStateException thrown by MonitorService is an intentional feature for demonstration purposes.

Changes:
- Added class-level documentation to MonitorService.java explaining its purpose
- Added method-level documentation to monitor() method clarifying the intentional exception
- Added documentation to Utils.throwException() explaining its role in exception simulation
- Added notes that these exceptions are for demonstration and testing purposes

This documentation will help prevent confusion about these exceptions being reported as critical errors, as they are part of the application's error simulation functionality.

Error ID referenced: 007553f8-4449-11f0-80e7-0242ac160004