### PR TITLE
Fix WebJars Bootstrap JavaScript resource loading-created-by-agentic

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/config/WebConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/config/WebConfig.java
@@ -1,0 +1,16 @@
+package org.springframework.samples.petclinic.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/webjars/**")
+                .addResourceLocations("classpath:/META-INF/resources/webjars/")
+                .resourceChain(true);
+    }
+}


### PR DESCRIPTION
This PR fixes the WebJars Bootstrap JavaScript resource loading failure by:

1. Adding proper WebMvcConfigurer configuration to handle WebJars resources
2. Configuring resource handler mapping for /webjars/** path
3. Setting correct classpath resource locations for WebJars

The changes ensure that Bootstrap's JavaScript bundle (bootstrap.bundle.min.js) and other WebJar resources are properly served from the correct paths.

Fixes the NoResourceFoundException when attempting to load from "bootstrap/5.2.3/dist/js/bootstrap.bundle.min.js".