### PR TITLE
Add index to clinic_activity_logs table for performance optimization-created-by-agentic

### DIFF
--- a/src/main/resources/db/migration/V2_1__Add_Index_To_Clinic_Activity_Logs.sql
+++ b/src/main/resources/db/migration/V2_1__Add_Index_To_Clinic_Activity_Logs.sql
@@ -1,0 +1,2 @@
+-- Add index to clinic_activity_logs table for numeric_value column
+CREATE INDEX IF NOT EXISTS idx_clinic_activity_logs_numeric_value ON clinic_activity_logs(numeric_value);


### PR DESCRIPTION
This PR addresses a severe performance degradation in the clinic activity logs query system.

Problem:
- Queries to /api/clinic-activity/query-logs endpoint are taking 4.71 seconds instead of 592.55 microseconds
- Missing index on the numeric_value column in clinic_activity_logs table
- Poor table buffer cache hit rate (3.9% vs recommended 95%)

Solution:
- Added an index on the numeric_value column of the clinic_activity_logs table
- This will improve query performance by avoiding full table scans

Expected Improvement:
- Query execution time should return to normal levels (around 592.55 microseconds)
- Better buffer cache utilization
- Reduced database load

Related Issues:
- 5aa1fb7a-3656-11f0-8db3-ca59c7e8e81d
- 14dbd63a-4554-11f0-b280-42975a299f33