### PR TITLE
Fix owners/pets endpoint to handle multiple pets per owner-created-by-agentic

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -18,9 +18,7 @@ package org.springframework.samples.petclinic.owner;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-
-import io.opentelemetry.api.OpenTelemetry;
+import java.util.stream.Collectors;import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
@@ -39,16 +37,13 @@ import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 
-import jakarta.validation.Valid;
-
-/**
+import jakarta.validation.Valid;/**
  * @author Juergen Hoeller
  * @author Ken Krebs
  * @author Arjen Poutsma
  * @author Michael Isvy
  */
-@Controller
-class OwnerController implements InitializingBean {
+@Controllerclass OwnerController implements InitializingBean {
 
 	private static final String VIEWS_OWNER_CREATE_OR_UPDATE_FORM = "owners/createOrUpdateOwnerForm";
 
@@ -81,9 +76,7 @@ class OwnerController implements InitializingBean {
 	@InitBinder
 	public void setAllowedFields(WebDataBinder dataBinder) {
 		dataBinder.setDisallowedFields("id");
-	}
-
-	@ModelAttribute("owner")
+	}@ModelAttribute("owner")
 	public Owner findOwner(@PathVariable(name = "ownerId", required = false) Integer ownerId) {
 		return ownerId == null ? new Owner() : this.owners.findById(ownerId);
 	}
@@ -111,9 +104,7 @@ class OwnerController implements InitializingBean {
 		this.owners.save(owner);
 		validator.ValidateUserAccess("admin", "pwd", "fullaccess");
 		return "redirect:/owners/" + owner.getId();
-	}
-
-	@GetMapping("/owners/find")
+	}@GetMapping("/owners/find")
 	public String initFindForm() {
 		return "owners/findOwners";
 	}
@@ -141,9 +132,7 @@ class OwnerController implements InitializingBean {
 			// 1 owner found
 			owner = ownersResults.iterator().next();
 			return "redirect:/owners/" + owner.getId();
-		}
-
-		// multiple owners found
+		}// multiple owners found
 		return addPaginationModel(page, model, ownersResults);
 	}
 
@@ -164,9 +153,7 @@ class OwnerController implements InitializingBean {
 		int pageSize = 5;
 		Pageable pageable = PageRequest.of(page - 1, pageSize);
 		return owners.findByLastName(lastname, pageable);
-	}
-
-	@GetMapping("/owners/{ownerId}/edit")
+	}@GetMapping("/owners/{ownerId}/edit")
 	public String initUpdateOwnerForm(@PathVariable("ownerId") int ownerId, Model model) {
 		Owner owner = this.owners.findById(ownerId);
 		var petCount = ownerRepository.countPets(owner.getId());
@@ -196,9 +183,7 @@ class OwnerController implements InitializingBean {
 		owner.setId(ownerId);
 		validator.checkOwnerValidity(owner);
 
-		validator.ValidateOwnerWithExternalService(owner);
-
-		validator.PerformValidationFlow(owner);
+		validator.ValidateOwnerWithExternalService(owner);validator.PerformValidationFlow(owner);
 		this.owners.save(owner);
 		return "redirect:/owners/{ownerId}";
 	}
@@ -228,11 +213,31 @@ class OwnerController implements InitializingBean {
 		List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql);
 
 		Map<Integer, List<Integer>> ownerToPetsMap = rows.stream()
-			.collect(Collectors.toMap(
+			.collect(Collectors.groupingBy(
 				row -> (Integer) row.get("owner_id"),
-				row -> List.of((Integer) row.get("pet_id"))  // Immutable list
+				Collectors.mapping(
+					row -> (Integer) row.get("pet_id"),
+					Collectors.toList()
+				)
 			));
 
+		List<Integer> pets = ownerToPetsMap.get(ownerId);
+
+		if (pets == null || pets.isEmpty()) {
+			return "No pets found for owner " + ownerId;
+		}
+
+		return "Pets for owner " + ownerId + ": " + pets.stream()
+			.map(String::valueOf)
+			.collect(Collectors.joining(", "));
+	}Map<Integer, List<Integer>> ownerToPetsMap = rows.stream()
+		.collect(Collectors.groupingBy(
+			row -> (Integer) row.get("owner_id"),
+			Collectors.mapping(
+				row -> (Integer) row.get("pet_id"),
+				Collectors.toList()
+			)
+		));
 
 		List<Integer> pets = ownerToPetsMap.get(ownerId);
 


### PR DESCRIPTION
This PR fixes the IllegalStateException in the owners/pets endpoint by properly handling multiple pets per owner.

Changes made:
1. Modified getOwnerPetsMap method to use Collectors.groupingBy() instead of toMap()
2. Implemented proper handling of multiple pets per owner using Collectors.mapping()
3. Maintained the same output format while fixing the underlying collection logic

The changes ensure that:
- Multiple pets per owner are handled correctly
- No duplicate key exceptions occur
- The endpoint returns the proper data structure

Note: The monitoring service exception (007553f8-4449-11f0-80e7-0242ac160004) is intentionally left unchanged as specified.