### PR TITLE
Add documentation for demonstration MonitorService-created-by-agentic

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/errors/MonitorService.java
+++ b/src/main/java/org/springframework/samples/petclinic/errors/MonitorService.java
@@ -9,7 +9,19 @@ import org.springframework.stereotype.Component;
 
 import java.util.InvalidPropertiesFormatException;
 
-@Component
+/**
+ * A demonstration service that generates artificial errors for monitoring and observability testing.
+ * This component is used to showcase error handling and monitoring capabilities in a demo environment.
+ * It should not be used in production systems.
+ */
+@Component/**
+ * A demonstration service class that simulates a monitoring system.
+ * This class is intended for educational and demonstration purposes only
+ * and should not be used in production environments.
+ * 
+ * The service runs a background thread that periodically executes monitoring
+ * operations to showcase OpenTelemetry instrumentation patterns.
+ */
 public class MonitorService implements SmartLifecycle {
 
 	private boolean running = false;
@@ -31,14 +43,17 @@ public class MonitorService implements SmartLifecycle {
 					throw new RuntimeException(e);
 				}
 				Span span = otelTracer.spanBuilder("monitor").startSpan();
+				// Add demo attribute to the span
+				span.setAttribute("demo.service", "true");
 
 				try {
-
 					System.out.println("Background service is running...");
 					monitor();
 				} catch (Exception e) {
 					span.recordException(e);
 					span.setStatus(StatusCode.ERROR);
+					// Add demo error attribute
+					span.setAttribute("demo.error", "true");
 				} finally {
 					span.end();
 				}
@@ -48,30 +63,34 @@ public class MonitorService implements SmartLifecycle {
 		// Start the background thread
 		backgroundThread.start();
 		System.out.println("Background service started.");
-	}
+	}    /**
+     * Demonstration method that simulates a monitoring failure.
+     * This method is intended to showcase error handling and monitoring patterns.
+     * It always throws an exception as part of the demonstration.
+     *
+     * @throws InvalidPropertiesFormatException when the monitor simulation fails
+     */
+    private void monitor() throws InvalidPropertiesFormatException {
+        Utils.throwException(IllegalStateException.class,"monitor failure");
+    }
 
-	private void monitor() throws InvalidPropertiesFormatException {
-		Utils.throwException(IllegalStateException.class,"monitor failure");
-	}
 
+    @Override
+    public void stop() {
+        // Stop the background task
+        running = false;
+        if (backgroundThread != null) {
+            try {
+                backgroundThread.join(); // Wait for the thread to finish
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        System.out.println("Background service stopped.");
+    }
 
-
-	@Override
-	public void stop() {
-		// Stop the background task
-		running = false;
-		if (backgroundThread != null) {
-			try {
-				backgroundThread.join(); // Wait for the thread to finish
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-			}
-		}
-		System.out.println("Background service stopped.");
-	}
-
-	@Override
-	public boolean isRunning() {
-		return false;
-	}
+    @Override
+    public boolean isRunning() {
+        return false;
+    }
 }


### PR DESCRIPTION
This PR adds proper documentation and OpenTelemetry attributes to the MonitorService class to clearly indicate its demonstration nature.

Changes:
- Added comprehensive JavaDoc to MonitorService class
- Added method-level documentation for monitor()
- Added OpenTelemetry attributes to mark errors as demonstration
- Added clear comments explaining the intentional error generation

This addresses the confusion around the intentional IllegalStateException being thrown every 5 seconds.