### PR TITLE
docs: Clarify intentional test exception in MonitorService-created-by-agentic

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/errors/MonitorService.java
+++ b/src/main/java/org/springframework/samples/petclinic/errors/MonitorService.java
@@ -9,7 +9,15 @@ import org.springframework.stereotype.Component;
 
 import java.util.InvalidPropertiesFormatException;
 
+/**
+ * Test service class that simulates error scenarios for monitoring and observability testing.
+ * This component is used to generate controlled error conditions in a test environment.
+ */
 @Component
+/**
+ * Test service class that simulates monitoring functionality.
+ * This class is intended for testing and demonstration purposes only.
+ */
 public class MonitorService implements SmartLifecycle {
 
 	private boolean running = false;
@@ -48,30 +56,34 @@ public class MonitorService implements SmartLifecycle {
 		// Start the background thread
 		backgroundThread.start();
 		System.out.println("Background service started.");
-	}
+	}/**
+ * Test method that simulates a monitoring failure scenario.
+ * This method is intended to always throw an exception for testing purposes.
+ *
+ * @throws InvalidPropertiesFormatException when monitor simulation fails
+ */
+private void monitor() throws InvalidPropertiesFormatException {
+    // Intentionally throw exception to simulate monitoring failure
+    Utils.throwException(IllegalStateException.class,"monitor failure");
+}
 
-	private void monitor() throws InvalidPropertiesFormatException {
-		Utils.throwException(IllegalStateException.class,"monitor failure");
-	}
 
+@Override
+public void stop() {
+    // Stop the background task
+    running = false;
+    if (backgroundThread != null) {
+        try {
+            backgroundThread.join(); // Wait for the thread to finish
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+    System.out.println("Background service stopped.");
+}
 
-
-	@Override
-	public void stop() {
-		// Stop the background task
-		running = false;
-		if (backgroundThread != null) {
-			try {
-				backgroundThread.join(); // Wait for the thread to finish
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-			}
-		}
-		System.out.println("Background service stopped.");
-	}
-
-	@Override
-	public boolean isRunning() {
-		return false;
-	}
+@Override
+public boolean isRunning() {
+    return false;
+}
 }


### PR DESCRIPTION
This PR adds documentation to clarify the intentional test exception in the MonitorService.

The IllegalStateException thrown in the monitor() method is an intentional test simulation for OpenTelemetry error handling and monitoring. This PR adds:

- Class-level JavaDoc explaining this is a test service
- Method-level JavaDoc for monitor() explaining the intentional exception
- Inline comments for better clarity

This will prevent future confusion about the expected error behavior.