### PR TITLE
Disable MonitorService error simulation-created-by-agentic

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/errors/MonitorService.java
+++ b/src/main/java/org/springframework/samples/petclinic/errors/MonitorService.java
@@ -9,8 +9,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.InvalidPropertiesFormatException;
 
-@Component
-public class MonitorService implements SmartLifecycle {
+@Componentpublic class MonitorService implements SmartLifecycle {
 
 	private boolean running = false;
 	private Thread backgroundThread;
@@ -48,12 +47,9 @@ public class MonitorService implements SmartLifecycle {
 		// Start the background thread
 		backgroundThread.start();
 		System.out.println("Background service started.");
+	}private void monitor() {
+		System.out.println("Monitoring is working normally");
 	}
-
-	private void monitor() throws InvalidPropertiesFormatException {
-		Utils.throwException(IllegalStateException.class,"monitor failure");
-	}
-
 
 
 	@Override


### PR DESCRIPTION
This PR disables the intentional error simulation in the MonitorService that was previously used for demonstration purposes. The simulation has served its purpose and is now being removed to reduce noise in the monitoring system.

Changes made:
- Modified the monitor() method to remove the intentional IllegalStateException
- Replaced with normal operation logging

This change will eliminate the 'monitor failure' exceptions that have been occurring in the monitoring system.