### PR TITLE
Fix 404 error handling implementation-created-by-agentic

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/system/GlobalExceptionHandler.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package org.springframework.samples.petclinic.system;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String handleNotFound(NoHandlerFoundException ex) {
+        return "errors/404";
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public String handleGeneralError(Exception ex) {
+        return "errors/error";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,10 @@
 # Server Port
 server.port=9753
 
+# Error Handling
+spring.mvc.throw-exception-if-no-handler-found=true
+spring.web.resources.add-mappings=false
+
 # database init, supports mysql too
 database=h2
 spring.sql.init.schema-locations=classpath*:db/${database}/schema.sql


### PR DESCRIPTION
This PR addresses the HumanNotFoundException issue by implementing proper error handling for undefined routes.

Changes made:
1. Added GlobalExceptionHandler to properly handle 404 and other errors
2. Updated application.properties to enable proper exception handling
3. Configured Spring MVC to throw exceptions for unhandled routes

Testing:
- Accessing undefined routes now returns proper 404 responses
- Error handling is consistent across all undefined route patterns
- Proper exception hierarchy is maintained

Fixes the issue where undefined routes were triggering HumanNotFoundException instead of returning standard 404 responses.