### PR TITLE
Fix WebJar paths for static resources-created-by-agentic

### DIFF
--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -17,11 +17,10 @@
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
 
-  <link th:href="@{/webjars/font-awesome/4.7.0/css/font-awesome.min.css}" rel="stylesheet">
+  <link th:href="@{/webjars/font-awesome/css/font-awesome.min.css}" rel="stylesheet">
   <link rel="stylesheet" th:href="@{/resources/css/petclinic.css}" />
 
 </head>
-
 <body>
 
   <nav class="navbar navbar-expand-lg navbar-dark" role="navigation">
@@ -29,8 +28,7 @@
       <a class="navbar-brand" th:href="@{/}"><span></span></a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main-navbar">
         <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="main-navbar" style>
+      </button><div class="collapse navbar-collapse" id="main-navbar" style>
 
         <ul class="navbar-nav me-auto mb-2 mb-lg-0" th:remove="all">
 
@@ -53,9 +51,7 @@
           <li th:replace="~{::menuItem ('/owners/find','owners','find owners','search','Find owners')}">
             <span class="fa fa-search" aria-hidden="true"></span>
             <span>Find owners</span>
-          </li>
-
-          <li th:replace="~{::menuItem ('/vets.html','vets','veterinarians','th-list','Veterinarians')}">
+          </li><li th:replace="~{::menuItem ('/vets.html','vets','veterinarians','th-list','Veterinarians')}">
             <span class="fa fa-th-list" aria-hidden="true"></span>
             <span>Veterinarians</span>
           </li>
@@ -74,8 +70,7 @@
         </ul>
       </div>
     </div>
-  </nav>
-  <div class="container-fluid">
+  </nav><div class="container-fluid">
     <div class="container xd-container">
 
       <th:block th:insert="${template}" />
@@ -92,7 +87,7 @@
     </div>
   </div>
 
-  <script th:src="@{/webjars/bootstrap/5.2.3/dist/js/bootstrap.bundle.min.js}"></script>
+  <script th:src="@{/webjars/bootstrap/dist/js/bootstrap.bundle.min.js}"></script>
 
 </body>
 


### PR DESCRIPTION
This PR fixes the static resource loading issue in the spring-petclinic service by updating the WebJar paths to follow the npm-based WebJar format.

Changes made:
1. Updated Bootstrap JS path from `/webjars/bootstrap/5.2.3/dist/js/bootstrap.bundle.min.js` to `/webjars/bootstrap/dist/js/bootstrap.bundle.min.js`
2. Updated Font Awesome CSS path from `/webjars/font-awesome/4.7.0/css/font-awesome.min.css` to `/webjars/font-awesome/css/font-awesome.min.css`

This fixes the NoResourceFoundException error (ID: 1251351a-4449-11f0-90fe-0242ac160004) by removing version numbers from WebJar paths, which is the correct format for npm-based WebJars.

Testing:
- Verified that the static resources load correctly
- Confirmed that the main page renders properly with all required CSS and JS files