### PR TITLE
Fix WebJar paths for npm-based bootstrap dependency-created-by-agentic

### DIFF
--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -20,17 +20,14 @@
   <link th:href="@{/webjars/font-awesome/4.7.0/css/font-awesome.min.css}" rel="stylesheet">
   <link rel="stylesheet" th:href="@{/resources/css/petclinic.css}" />
 
-</head>
-
-<body>
+</head><body>
 
   <nav class="navbar navbar-expand-lg navbar-dark" role="navigation">
     <div class="container-fluid">
       <a class="navbar-brand" th:href="@{/}"><span></span></a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main-navbar">
         <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="main-navbar" style>
+      </button><div class="collapse navbar-collapse" id="main-navbar" style>
 
         <ul class="navbar-nav me-auto mb-2 mb-lg-0" th:remove="all">
 
@@ -53,9 +50,7 @@
           <li th:replace="~{::menuItem ('/owners/find','owners','find owners','search','Find owners')}">
             <span class="fa fa-search" aria-hidden="true"></span>
             <span>Find owners</span>
-          </li>
-
-          <li th:replace="~{::menuItem ('/vets.html','vets','veterinarians','th-list','Veterinarians')}">
+          </li><li th:replace="~{::menuItem ('/vets.html','vets','veterinarians','th-list','Veterinarians')}">
             <span class="fa fa-th-list" aria-hidden="true"></span>
             <span>Veterinarians</span>
           </li>
@@ -74,8 +69,7 @@
         </ul>
       </div>
     </div>
-  </nav>
-  <div class="container-fluid">
+  </nav><div class="container-fluid">
     <div class="container xd-container">
 
       <th:block th:insert="${template}" />
@@ -92,7 +86,7 @@
     </div>
   </div>
 
-  <script th:src="@{/webjars/bootstrap/5.2.3/dist/js/bootstrap.bundle.min.js}"></script>
+  <script th:src="@{/webjars/bootstrap/js/bootstrap.bundle.min.js}"></script>
 
 </body>
 


### PR DESCRIPTION
This PR fixes the WebJar path misconfiguration in the PetClinic service. The application is using npm-based WebJars (org.webjars.npm:bootstrap) but was attempting to access resources using classic WebJar path structure.

Changes made:
- Updated WebJar paths in layout.html to match npm structure
- Changed from `/webjars/bootstrap/5.2.3/dist/js/bootstrap.bundle.min.js` to `/webjars/bootstrap/js/bootstrap.bundle.min.js`

This fixes the error:
- Error ID: 1251351a-4449-11f0-90fe-0242ac160004
- Error Type: org.springframework.web.servlet.resource.NoResourceFoundException
- Error Message: No static resource bootstrap/5.2.3/dist/js/bootstrap.bundle.min.js

Testing:
- Please verify that the bootstrap resources load correctly after this change
- Check that the frontend styling and JavaScript functionality works as expected