### PR TITLE
Fix pet duplicate key handling and add monitor documentation-created-by-agentic

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/errors/MonitorService.java
+++ b/src/main/java/org/springframework/samples/petclinic/errors/MonitorService.java
@@ -9,6 +9,10 @@ import org.springframework.stereotype.Component;
 
 import java.util.InvalidPropertiesFormatException;
 
+/**
+ * A demo service that intentionally throws exceptions to showcase error handling and monitoring capabilities.
+ * This service is part of the demo features and should not be used in production.
+ */
 @Component
 public class MonitorService implements SmartLifecycle {
 
@@ -33,7 +37,6 @@ public class MonitorService implements SmartLifecycle {
 				Span span = otelTracer.spanBuilder("monitor").startSpan();
 
 				try {
-
 					System.out.println("Background service is running...");
 					monitor();
 				} catch (Exception e) {
@@ -50,10 +53,16 @@ public class MonitorService implements SmartLifecycle {
 		System.out.println("Background service started.");
 	}
 
+	/**
+	 * Demo method that intentionally throws an IllegalStateException.
+	 * This is used to demonstrate error handling and monitoring capabilities.
+	 * DO NOT USE IN PRODUCTION.
+	 *
+	 * @throws InvalidPropertiesFormatException This exception is part of the demo
+	 */
 	private void monitor() throws InvalidPropertiesFormatException {
 		Utils.throwException(IllegalStateException.class,"monitor failure");
 	}
-
 
 
 	@Override

--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -20,9 +20,7 @@ import java.util.List;
 
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.samples.petclinic.model.Person;
-import org.springframework.util.Assert;
-
-import jakarta.persistence.CascadeType;
+import org.springframework.util.Assert;import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -43,8 +41,7 @@ import jakarta.validation.constraints.NotBlank;
  * @author Oliver Drotbohm
  */
 @Entity
-@Table(name = "owners")
-public class Owner extends Person {
+@Table(name = "owners")public class Owner extends Person {
 
 	@Column(name = "address")
 	@NotBlank
@@ -95,10 +92,20 @@ public class Owner extends Person {
 	public void addPet(Pet pet) {
 		if (pet.isNew()) {
 			getPets().add(pet);
+		} else {
+			// If pet has an ID, check if it exists
+			Pet existingPet = getPet(pet.getId());
+			if (existingPet != null) {
+				// Update existing pet's properties
+				existingPet.setName(pet.getName());
+				existingPet.setBirthDate(pet.getBirthDate());
+				existingPet.setType(pet.getType());
+			} else {
+				getPets().add(pet);
+			}
 		}
-	}
-
-	/**
+		pet.setOwner(this);
+	}/**
 	 * Return the Pet with the given name, or null if none found for this Owner.
 	 * @param name to test
 	 * @return a pet if pet name is already in use
@@ -122,9 +129,7 @@ public class Owner extends Person {
 			}
 		}
 		return null;
-	}
-
-	/**
+	}/**
 	 * Return the Pet with the given name, or null if none found for this Owner.
 	 * @param name to test
 	 * @return a pet if pet name is already in use
@@ -152,9 +157,7 @@ public class Owner extends Person {
 			.append("city", this.city)
 			.append("telephone", this.telephone)
 			.toString();
-	}
-
-	/**
+	}/**
 	 * Adds the given {@link Visit} to the {@link Pet} with the given identifier.
 	 * @param petId the identifier of the {@link Pet}, must not be {@literal null}.
 	 * @param visit the visit to add, must not be {@literal null}.


### PR DESCRIPTION
This PR addresses two issues:

1. MonitorService IllegalStateException Documentation
- Added clear documentation to indicate that the IllegalStateException in MonitorService is an intentional demo feature
- Added JavaDoc comments explaining the purpose of the monitor() method
- Made it clear that this is not for production use

2. Pets Endpoint Duplicate Key Exception Fix
- Fixed the duplicate key handling in Owner.addPet() method
- Added proper handling for existing pets with the same ID
- Implemented update logic for existing pets instead of attempting to add duplicates
- Added setOwner call to maintain proper object relationships

The changes ensure that:
- Demo features are properly documented
- Pet updates work correctly without duplicate key errors
- Existing pets are properly updated instead of causing conflicts

Testing:
- The MonitorService will continue to throw the demo exception but now with clear documentation
- Pet updates should work without duplicate key errors
- Existing pets should be properly updated