### PR TITLE
Optimize query-logs endpoint performance with new indexes-created-by-agentic

### DIFF
--- a/src/main/resources/db/postgres/schema.sql
+++ b/src/main/resources/db/postgres/schema.sql
@@ -53,10 +53,14 @@ CREATE INDEX IF NOT EXISTS visits_pet_id ON visits (pet_id);
 
 -- New table for clinic activity logging
 CREATE TABLE IF NOT EXISTS clinic_activity_logs (
-  id                    SERIAL PRIMARY KEY,
-  activity_type         VARCHAR(255),
-  numeric_value         INTEGER,
+  id                      SERIAL PRIMARY KEY,
+  activity_type          VARCHAR(255),
+  numeric_value          INTEGER,
   event_timestamp       TIMESTAMP,
   status_flag           BOOLEAN,
   payload               TEXT
 );
+
+-- Performance optimization indexes
+CREATE INDEX IF NOT EXISTS crystaldba_idx_clinic_activity_logs_numeric_value_1 ON clinic_activity_logs USING btree (numeric_value);
+CREATE INDEX IF NOT EXISTS crystaldba_idx_clinic_activity_logs_composite_1 ON clinic_activity_logs USING btree (numeric_value, activity_type, event_timestamp);


### PR DESCRIPTION
This PR addresses the severe performance degradation in the /query-logs endpoint by adding two new indexes to the clinic_activity_logs table:

1. A B-tree index on the numeric_value column (crystaldba_idx_clinic_activity_logs_numeric_value_1)
2. A composite index on (numeric_value, activity_type, event_timestamp) to better support common query patterns

Changes made:
- Added single-column B-tree index on numeric_value for efficient value lookups
- Added composite index to support queries that filter on numeric_value and include activity_type and event_timestamp in the result set

These changes are expected to significantly improve query performance by:
- Reducing full table scans
- Providing efficient index-only scans for common query patterns
- Supporting both equality and range queries on numeric_value

The indexes have been added with IF NOT EXISTS clauses to ensure idempotent application.