### PR TITLE
Add index on clinic_activity_logs(numeric_value) for query performance-created-by-agentic

### DIFF
--- a/src/main/resources/db/postgres/schema.sql
+++ b/src/main/resources/db/postgres/schema.sql
@@ -53,10 +53,12 @@ CREATE INDEX IF NOT EXISTS visits_pet_id ON visits (pet_id);
 
 -- New table for clinic activity logging
 CREATE TABLE IF NOT EXISTS clinic_activity_logs (
-  id                    SERIAL PRIMARY KEY,
-  activity_type         VARCHAR(255),
-  numeric_value         INTEGER,
+  id                      SERIAL PRIMARY KEY,
+  activity_type          VARCHAR(255),
+  numeric_value          INTEGER,
   event_timestamp       TIMESTAMP,
   status_flag           BOOLEAN,
   payload               TEXT
 );
+-- Index for improving query performance on numeric_value column
+CREATE INDEX IF NOT EXISTS idx_clinic_activity_logs_numeric_value ON clinic_activity_logs(numeric_value);


### PR DESCRIPTION
This PR addresses the performance degradation issue in the /query-logs endpoint where query duration increased from 525.5μs to 4.25s.

Changes made:
1. Added an index on the numeric_value column of the clinic_activity_logs table
2. Updated schema.sql to include the new index definition

The index will improve query performance by:
- Reducing full table scans
- Providing faster access to rows based on numeric_value
- Optimizing ORDER BY and GROUP BY operations on the numeric_value column

Testing:
- Index has been created in the database
- Table statistics have been updated
- Query performance should be monitored after deployment

Related incident: Query-Logs Endpoint Severe Performance Degradation