### PR TITLE
Add index on clinic_activity_logs.numeric_value for query performance-created-by-agentic

### DIFF
--- a/src/main/resources/db/postgres/schema.sql
+++ b/src/main/resources/db/postgres/schema.sql
@@ -53,10 +53,13 @@ CREATE INDEX IF NOT EXISTS visits_pet_id ON visits (pet_id);
 
 -- New table for clinic activity logging
 CREATE TABLE IF NOT EXISTS clinic_activity_logs (
-  id                    SERIAL PRIMARY KEY,
-  activity_type         VARCHAR(255),
-  numeric_value         INTEGER,
+  id                      SERIAL PRIMARY KEY,
+  activity_type          VARCHAR(255),
+  numeric_value          INTEGER,
   event_timestamp       TIMESTAMP,
   status_flag           BOOLEAN,
   payload               TEXT
 );
+
+-- Add index for numeric_value to improve query performance
+CREATE INDEX IF NOT EXISTS crystaldba_idx_clinic_activity_logs_numeric_value_1 ON clinic_activity_logs USING btree (numeric_value);


### PR DESCRIPTION
This PR addresses the severe performance degradation in the /query-logs endpoint by adding a btree index on the numeric_value column of the clinic_activity_logs table.

Problem:
- The /query-logs endpoint response time increased from 525.5μs to 4.26s
- Root cause identified as missing index on frequently queried numeric_value column

Solution:
1. Added btree index on clinic_activity_logs.numeric_value
2. Index name: crystaldba_idx_clinic_activity_logs_numeric_value_1
3. Updated schema.sql to include the index creation for future deployments

Performance Impact:
- Expected significant improvement in query performance
- Will reduce full table scans on clinic_activity_logs table
- Should bring response times back to normal levels (~525.5μs)

Additional Notes:
- Database health check shows no other critical index issues
- Buffer cache hit rates could be improved (currently at 22.8% for tables)
- Will monitor query performance after index creation through Digma monitoring