### PR TITLE
Fix Webjars Bootstrap Resource Not Found Error-created-by-agentic

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,3 +29,9 @@ logging.level.org.springframework=INFO
 
 # Maximum time static resources should be cached
 spring.web.resources.cache.cachecontrol.max-age=12h
+
+# Webjars configuration
+spring.mvc.static-path-pattern=/webjars/**
+spring.web.resources.static-locations=classpath:/META-INF/resources/webjars/
+spring.web.resources.chain.strategy.content.enabled=true
+spring.web.resources.chain.strategy.content.paths=/webjars/**


### PR DESCRIPTION
This PR addresses the Webjars Bootstrap Resource Not Found Error by:

1. Adding proper Webjars resource configuration in application.properties:
   - Configured static path pattern for webjars
   - Set up proper resource chain strategy
   - Added static locations configuration

2. Important Note:
   The CSS profile must be activated during build using:
   ```bash
   ./mvnw clean package -P css
   ```
   This ensures Bootstrap resources are properly unpacked to the target/webjars directory.

The changes ensure that Bootstrap resources are properly served through the webjar path.