### PR TITLE
Add index on numeric_value column for clinic_activity_logs table-created-by-agentic

### DIFF
--- a/src/main/resources/db/postgres/schema.sql
+++ b/src/main/resources/db/postgres/schema.sql
@@ -53,10 +53,11 @@ CREATE INDEX IF NOT EXISTS visits_pet_id ON visits (pet_id);
 
 -- New table for clinic activity logging
 CREATE TABLE IF NOT EXISTS clinic_activity_logs (
-  id                    SERIAL PRIMARY KEY,
-  activity_type         VARCHAR(255),
-  numeric_value         INTEGER,
+  id                      SERIAL PRIMARY KEY,
+  activity_type          VARCHAR(255),
+  numeric_value          INTEGER,
   event_timestamp       TIMESTAMP,
   status_flag           BOOLEAN,
   payload               TEXT
 );
+CREATE INDEX IF NOT EXISTS idx_clinic_activity_logs_numeric_value ON clinic_activity_logs(numeric_value);


### PR DESCRIPTION
This PR addresses the performance degradation issue in the /query-logs endpoint by adding an index on the numeric_value column of the clinic_activity_logs table.

Changes made:
1. Added index idx_clinic_activity_logs_numeric_value on clinic_activity_logs(numeric_value)

This change will improve query performance by:
- Reducing full table scans when querying on numeric_value
- Improving sort operations that use numeric_value
- Reducing overall query execution time

The index has been added to both the PostgreSQL schema file to ensure it's created for new deployments.