### PR TITLE
Fix N+1 Query Performance Issue in Owner Management

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Owner.java
@@ -20,9 +20,7 @@ import java.util.List;
 
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.samples.petclinic.model.Person;
-import org.springframework.util.Assert;
-
-import jakarta.persistence.CascadeType;
+import org.springframework.util.Assert;import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -43,8 +41,7 @@ import jakarta.validation.constraints.NotBlank;
  * @author Oliver Drotbohm
  */
 @Entity
-@Table(name = "owners")
-public class Owner extends Person {
+@Table(name = "owners")public class Owner extends Person {
 
 	@Column(name = "address")
 	@NotBlank
@@ -59,7 +56,7 @@ public class Owner extends Person {
 	@Digits(fraction = 0, integer = 10)
 	private String telephone;
 
-	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	@JoinColumn(name = "owner_id")
 	@OrderBy("name")
 	private List<Pet> pets = new ArrayList<>();
@@ -96,9 +93,7 @@ public class Owner extends Person {
 		if (pet.isNew()) {
 			getPets().add(pet);
 		}
-	}
-
-	/**
+	}/**
 	 * Return the Pet with the given name, or null if none found for this Owner.
 	 * @param name to test
 	 * @return a pet if pet name is already in use
@@ -122,9 +117,7 @@ public class Owner extends Person {
 			}
 		}
 		return null;
-	}
-
-	/**
+	}/**
 	 * Return the Pet with the given name, or null if none found for this Owner.
 	 * @param name to test
 	 * @return a pet if pet name is already in use
@@ -152,9 +145,7 @@ public class Owner extends Person {
 			.append("city", this.city)
 			.append("telephone", this.telephone)
 			.toString();
-	}
-
-	/**
+	}/**
 	 * Adds the given {@link Visit} to the {@link Pet} with the given identifier.
 	 * @param petId the identifier of the {@link Pet}, must not be {@literal null}.
 	 * @param visit the visit to add, must not be {@literal null}.

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
@@ -15,9 +15,7 @@
  */
 package org.springframework.samples.petclinic.owner;
 
-import java.util.List;
-
-import org.springframework.data.domain.Page;
+import java.util.List;import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -34,8 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Juergen Hoeller
  * @author Sam Brannen
  * @author Michael Isvy
- */
-public interface OwnerRepository extends Repository<Owner, Integer> {
+ */public interface OwnerRepository extends Repository<Owner, Integer> {
 
 	/**
 	 * Retrieve all {@link PetType}s from the data store.
@@ -53,11 +50,10 @@ public interface OwnerRepository extends Repository<Owner, Integer> {
 	 * found)
 	 */
 
-	@Query("SELECT DISTINCT owner FROM Owner owner left join  owner.pets WHERE owner.lastName LIKE :lastName% ")
+	@Query("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets WHERE owner.lastName LIKE :lastName% ")
 	@Transactional(readOnly = true)
 	Page<Owner> findByLastName(@Param("lastName") String lastName, Pageable pageable);
-
-	/**
+/**
 	 * Retrieve an {@link Owner} from the data store by id.
 	 * @param id the id to search for
 	 * @return the {@link Owner} if found
@@ -79,7 +75,7 @@ public interface OwnerRepository extends Repository<Owner, Integer> {
 	/**
 	 * Returns all the owners from data store
 	 **/
-	@Query("SELECT owner FROM Owner owner")
+	@Query("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets")
 	@Transactional(readOnly = true)
 	Page<Owner> findAll(Pageable pageable);
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
@@ -21,9 +21,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.samples.petclinic.model.NamedEntity;
-
-import jakarta.persistence.CascadeType;
+import org.springframework.samples.petclinic.model.NamedEntity;import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -41,8 +39,7 @@ import jakarta.persistence.Table;
  * @author Sam Brannen
  */
 @Entity
-@Table(name = "pets")
-public class Pet extends NamedEntity {
+@Table(name = "pets")public class Pet extends NamedEntity {
 
 	@Column(name = "birth_date")
 	@DateTimeFormat(pattern = "yyyy-MM-dd")
@@ -52,7 +49,7 @@ public class Pet extends NamedEntity {
 	@JoinColumn(name = "type_id")
 	private PetType type;
 
-	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+	@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	@JoinColumn(name = "pet_id")
 	@OrderBy("visit_date ASC")
 	private Set<Visit> visits = new LinkedHashSet<>();


### PR DESCRIPTION
This PR addresses the N+1 query performance issue in owner management operations by:

1. Modifying Owner entity to use lazy loading for pets collection
2. Modifying Pet entity to use lazy loading for visits collection
3. Optimizing OwnerRepository queries to use JOIN FETCH for efficient loading

These changes will improve performance for the affected endpoints:
- `/owners/{ownerId}/edit`
- `/owners/new`

The modifications maintain backward compatibility while reducing unnecessary database queries.

Related issue: #4391c308-3b9b-11f0-899b-42975a299f33
Related errors: 
- b2f3824a-3655-11f0-bc70-ca59c7e8e81d
- d60cbb62-3f3c-11f0-803c-42975a299f33