### PR TITLE
Add index on numeric_value column in clinic_activity_logs table

### DIFF
--- a/src/main/resources/db/migration/V1__Add_numeric_value_index.sql
+++ b/src/main/resources/db/migration/V1__Add_numeric_value_index.sql
@@ -1,0 +1,6 @@
+-- Add index on numeric_value column for improved query performance
+CREATE INDEX IF NOT EXISTS idx_clinic_activity_logs_numeric_value 
+ON clinic_activity_logs(numeric_value);
+
+-- Rollback statement (will be used by Flyway when rolling back this migration)
+-- DROP INDEX IF EXISTS idx_clinic_activity_logs_numeric_value;


### PR DESCRIPTION
This PR adds a database migration to create an index on the numeric_value column in the clinic_activity_logs table. This change is intended to improve query performance for the /api/clinic-activity/query-logs endpoint which has been experiencing severe performance degradation.

Changes:
- Added new Flyway migration file to create an index on numeric_value column
- Migration is idempotent with CREATE INDEX IF NOT EXISTS
- Included commented rollback statement for version control

Related issue: #5aa1fb7a-3656-11f0-8db3-ca59c7e8e81d