### PR TITLE
Add index on numeric_value column in clinic_activity_logs table

### DIFF
--- a/src/main/resources/db/migration/V2__Add_index_to_clinic_activity_logs.sql
+++ b/src/main/resources/db/migration/V2__Add_index_to_clinic_activity_logs.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_clinic_activity_logs_numeric_value ON clinic_activity_logs(numeric_value);


### PR DESCRIPTION
This PR adds a database migration to create an index on the numeric_value column of the clinic_activity_logs table. This change is intended to improve query performance for the Query Logs endpoint which is currently experiencing severe performance degradation.

Changes:
- Added new migration file V2__Add_index_to_clinic_activity_logs.sql
- Creates B-tree index idx_clinic_activity_logs_numeric_value on numeric_value column

Related to issue: #5aa1fb7a-3656-11f0-8db3-ca59c7e8e81d

The index will help improve query performance by allowing the database to quickly locate rows based on numeric_value without having to scan the entire table.