### PR TITLE
Fix division by zero exception in OwnerController.showOwner()

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -19,8 +19,7 @@ import java.util.Map;
 import java.util.stream.Collectors;import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.opentelemetry.api.trace.Tracer;import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -38,9 +37,7 @@ import org.springframework.web.bind.annotation.*;import org.springframework.web.
  * @author Arjen Poutsma
  * @author Michael Isvy
  */
-@Controllerclass OwnerController implements InitializingBean {
-
-	private static final String VIEWS_OWNER_CREATE_OR_UPDATE_FORM = "owners/createOrUpdateOwnerForm";
+@Controllerclass OwnerController implements InitializingBean {private static final String VIEWS_OWNER_CREATE_OR_UPDATE_FORM = "owners/createOrUpdateOwnerForm";
 
 	private OwnerValidation validator;
 
@@ -72,9 +69,7 @@ import org.springframework.web.bind.annotation.*;import org.springframework.web.
 	}@ModelAttribute("owner")
 	public Owner findOwner(@PathVariable(name = "ownerId", required = false) Integer ownerId) {
 		return ownerId == null ? new Owner() : this.owners.findById(ownerId);
-	}
-
-	@GetMapping("/owners/new")
+	}@GetMapping("/owners/new")
 	public String initCreationForm(Map<String, Object> model) {
 		Owner owner = new Owner();
 		validator.ValidateOwnerWithExternalService(owner);
@@ -98,9 +93,7 @@ import org.springframework.web.bind.annotation.*;import org.springframework.web.
 	}@GetMapping("/owners/find")
 	public String initFindForm() {
 		return "owners/findOwners";
-	}
-
-	@GetMapping("/owners")
+	}@GetMapping("/owners")
 	public String processFindForm(@RequestParam(defaultValue = "1") int page, Owner owner, BindingResult result,
 			Model model) {
 
@@ -123,9 +116,7 @@ import org.springframework.web.bind.annotation.*;import org.springframework.web.
 			return "redirect:/owners/" + owner.getId();
 		}// multiple owners found
 		return addPaginationModel(page, model, ownersResults);
-	}
-
-	@WithSpan
+	}@WithSpan
 	private String addPaginationModel(int page, Model model, Page<Owner> paginated) {
 		// throw new RuntimeException();
 		model.addAttribute("listOwners", paginated);
@@ -147,9 +138,7 @@ import org.springframework.web.bind.annotation.*;import org.springframework.web.
 		Owner owner = this.owners.findByIdWithPets(ownerId);
 		model.addAttribute(owner);
 		return VIEWS_OWNER_CREATE_OR_UPDATE_FORM;
-	}
-
-	private static void delay(long millis) {
+	}private static void delay(long millis) {
 		try {
 			Thread.sleep(millis);
 		}
@@ -180,12 +169,10 @@ validator.ValidateOwnerWithExternalService(owner);
 	 */
 	@GetMapping("/owners/{ownerId}")
 	public ModelAndView showOwner(@PathVariable("ownerId") int ownerId) {
-		validator.ValidateUserAccess("admin", "pwd", "fullaccess");
-
-		ModelAndView mav = new ModelAndView("owners/ownerDetails");
+		validator.ValidateUserAccess("admin", "pwd", "fullaccess");ModelAndView mav = new ModelAndView("owners/ownerDetails");
 		Owner owner = this.owners.findByIdWithPets(ownerId);
 		validator.ValidateOwnerWithExternalService(owner);
-		int petFactor = 1 / owner.getPets().size();
+		int petFactor = (owner.getPets() == null || owner.getPets().size() == 0) ? 1 : 1 / owner.getPets().size();
 		System.out.println(petFactor);
 		mav.addObject(owner);
 		return mav;
@@ -195,10 +182,7 @@ validator.ValidateOwnerWithExternalService(owner);
 	@ResponseBody
 	public List<Pet> getOwnerPetsMap(@PathVariable("ownerId") int ownerId) {
 		return this.owners.findPetsByOwnerId(ownerId);
-	}@Autowired
-private OwnerRepository ownerRepository;
-
-public String getPetsForOwner(Integer ownerId) {
+	}@Autowiredprivate OwnerRepository ownerRepository;public String getPetsForOwner(Integer ownerId) {
     Owner owner = ownerRepository.findOwnerWithPets(ownerId)
         .orElseThrow(() -> new ResourceNotFoundException("Owner not found"));
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -18,8 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.api.trace.Tracer;import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.opentelemetry.api.trace.SpanKind;import io.opentelemetry.api.trace.Tracer;import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -36,10 +35,7 @@ import org.springframework.web.bind.annotation.*;import org.springframework.web.
  * @author Ken Krebs
  * @author Arjen Poutsma
  * @author Michael Isvy
- */
-@Controllerclass OwnerController implements InitializingBean {private static final String VIEWS_OWNER_CREATE_OR_UPDATE_FORM = "owners/createOrUpdateOwnerForm";
-
-	private OwnerValidation validator;
+ */@Controllerclass OwnerController implements InitializingBean {private static final String VIEWS_OWNER_CREATE_OR_UPDATE_FORM = "owners/createOrUpdateOwnerForm";private OwnerValidation validator;
 
 	@Autowired
 	private OpenTelemetry openTelemetry;
@@ -58,9 +54,7 @@ import org.springframework.web.bind.annotation.*;import org.springframework.web.
 	private final OwnerRepository owners;
 	private final JdbcTemplate jdbcTemplate;
 
-	public OwnerController(OwnerRepository clinicService, JdbcTemplate jdbcTemplate
-
-	) {
+	public OwnerController(OwnerRepository clinicService, JdbcTemplate jdbcTemplate) {
 		this.owners = clinicService;
 		this.jdbcTemplate = jdbcTemplate;
 	}@InitBinder
@@ -78,9 +72,7 @@ import org.springframework.web.bind.annotation.*;import org.springframework.web.
 		validator.ValidateUserAccess("admin", "pwd", "fullaccess");
 
 		return VIEWS_OWNER_CREATE_OR_UPDATE_FORM;
-	}
-
-	@PostMapping("/owners/new")
+	}@PostMapping("/owners/new")
 	public String processCreationForm(@Valid Owner owner, BindingResult result) {
 		if (result.hasErrors()) {
 			return VIEWS_OWNER_CREATE_OR_UPDATE_FORM;
@@ -102,9 +94,7 @@ import org.springframework.web.bind.annotation.*;import org.springframework.web.
 		// allow parameterless GET request for /owners to return all records
 		if (owner.getLastName() == null) {
 			owner.setLastName(""); // empty string signifies broadest possible search
-		}
-
-		// find owners by last name
+		}// find owners by last name
 		Page<Owner> ownersResults = findPaginatedForOwnersLastName(page, owner.getLastName());
 		if (ownersResults.isEmpty()) {
 			// no owners found
@@ -125,15 +115,12 @@ import org.springframework.web.bind.annotation.*;import org.springframework.web.
 		model.addAttribute("totalPages", paginated.getTotalPages());
 		model.addAttribute("totalItems", paginated.getTotalElements());
 		model.addAttribute("listOwners", listOwners);
-		return "owners/ownersList";
-	}@WithSpan()
+		return "owners/ownersList";}@WithSpan()
 	private Page<Owner> findPaginatedForOwnersLastName(int page, String lastname) {
 		int pageSize = 5;
 		Pageable pageable = PageRequest.of(page - 1, pageSize);
 		return owners.findByLastNameWithPets(lastname, pageable);
-	}
-
-	@GetMapping("/owners/{ownerId}/edit")
+	}@GetMapping("/owners/{ownerId}/edit")
 	public String initUpdateOwnerForm(@PathVariable("ownerId") int ownerId, Model model) {
 		Owner owner = this.owners.findByIdWithPets(ownerId);
 		model.addAttribute(owner);
@@ -160,9 +147,7 @@ validator.ValidateOwnerWithExternalService(owner);
 	}validator.PerformValidationFlow(owner);
 		this.owners.save(owner);
 		return "redirect:/owners/{ownerId}";
-	}
-
-	/**
+	}/**
 	 * Custom handler for displaying an owner.
 	 * @param ownerId the ID of the owner to display
 	 * @return a ModelMap with the model attributes for the view
@@ -172,13 +157,16 @@ validator.ValidateOwnerWithExternalService(owner);
 		validator.ValidateUserAccess("admin", "pwd", "fullaccess");ModelAndView mav = new ModelAndView("owners/ownerDetails");
 		Owner owner = this.owners.findByIdWithPets(ownerId);
 		validator.ValidateOwnerWithExternalService(owner);
-		int petFactor = (owner.getPets() == null || owner.getPets().size() == 0) ? 1 : 1 / owner.getPets().size();
+		int petFactor;
+		if (owner.getPets() != null && owner.getPets().size() > 0) {
+			petFactor = 1 / owner.getPets().size();
+		} else {
+			petFactor = 1;
+		}
 		System.out.println(petFactor);
 		mav.addObject(owner);
 		return mav;
-	}
-
-	@GetMapping("/owners/{ownerId}/pets")
+	}@GetMapping("/owners/{ownerId}/pets")
 	@ResponseBody
 	public List<Pet> getOwnerPetsMap(@PathVariable("ownerId") int ownerId) {
 		return this.owners.findPetsByOwnerId(ownerId);


### PR DESCRIPTION
## Description
Fixes the division by zero exception that occurs in the `OwnerController.showOwner()` method at line 180 when an owner has no pets.

## Root Cause
The problematic line `int petFactor = 1 / owner.getPets().size();` attempts to divide by zero when `owner.getPets().size()` returns 0, which happens when an owner has no pets.

## Solution
Added a guard check before the division operation to handle the case when the pet list is empty. If `owner.getPets()` is null or empty (size == 0), `petFactor` is set to a safe default value of 1.

## Error Details
- **Error ID**: 555222fc-ca6d-11f0-af58-22f2dd697fbe
- **Affected Endpoint**: GET /owners/{ownerId}
- **Service**: spring-petclinic.main
- **Affected Owner**: Owner ID 11 (Roni Dover) with zero pets

## Testing
This fix should resolve the ArithmeticException when accessing owner profiles with no pets. Monitor error ID 555222fc-ca6d-11f0-af58-22f2dd697fbe in the Digma environment to confirm resolution.